### PR TITLE
Update index.js

### DIFF
--- a/chapter-2/lib/configuration/index.js
+++ b/chapter-2/lib/configuration/index.js
@@ -2,7 +2,7 @@ var nconf = require('nconf');
 
 function Config(){
   nconf.argv().env('_');
-  var environment = nconf.get('NODE:ENV') || 'development';
+  var environment = nconf.get('NODE:ENV').toLowerCase() || 'development';
   nconf.file(environment, 'config/' + environment + '.json');
   nconf.file('default', 'config/default.json');
 }


### PR DESCRIPTION
Added lowercase conversion of environment variable. On OS X, this variable is returned lowercase. On Linux, it will be returned uppercase, which will cause other code which attempts to load test.json, or any other environment-specific named file to fail on Linux.
